### PR TITLE
Typos and grammar agreement + clarity

### DIFF
--- a/src/components/feature.vue
+++ b/src/components/feature.vue
@@ -18,7 +18,7 @@
       <li>
         <h3>Code Fence</h3>
         <img src="../assets/images/code-block.jpg" alt="">
-        <div>Support all the popular language</div>
+        <div>Support for all the popular languages</div>
       </li>
     </ul>
   </div>

--- a/src/components/feature.vue
+++ b/src/components/feature.vue
@@ -2,7 +2,7 @@
   <div class="features">
     <h2>Editor</h2>
     <div class="intro">
-      Mark Text support CommonMark Spec and GitHub Flavored Markdown Spec. And it is a realtime preview editor, what you type is what you see finally.
+      Mark Text supports both the CommonMark Spec and the GitHub Flavored Markdown Spec. It is a realtime preview editor: text styles and formatting update as you type.
     </div>
     <ul class="feature-intro">
       <li>

--- a/src/components/mode.vue
+++ b/src/components/mode.vue
@@ -2,7 +2,7 @@
   <div class="edit-mode">
     <h2>Edit Mode</h2>
     <div class="intro">
-      Various edit mode: Source Code mode、Typewriter mode、Focus mode.
+      Various edit modes: Source Code mode, Typewriter mode, and Focus mode.
     </div>
     <h3>Source Code Mode</h3>
     <div class="image-wrapper">
@@ -14,7 +14,7 @@
     </div>
     <h2>Issues</h2>
     <div class="intro center">
-      If you find any bugs of Mark Text, or have a great idea want to tell us ?
+      If you find any bugs or have a great idea for Mark Text, please let us know!
     </div>
     <div class="center issue-button">
       <a href="https://github.com/marktext/marktext/issues" target="blank">Shoot an Issue</a>


### PR DESCRIPTION
`feature.vue`

> Support[ for][1] all the popular language[s][2]

[1] Missing " for" could also say "Supports all the popular languages" but I like above/committed version better.

[2] Plural Agreement
https://en.wikipedia.org/wiki/Agreement_(linguistics)#Number
https://en.wikipedia.org/wiki/Plural


> Mark Text support[s both the] CommonMark Spec and[ the] GitHub Flavored Markdown Spec.

agreement again + clarity

> It is a realtime preview editor[: text styles and formatting update as you type].

clarity



`mode.vue`

> Various edit mode[s]: Source Code mode[,] Typewriter mode[, and] Focus mode.

agreement; make mode list into regular comma series 


> If you find any bugs [or have a great idea for Mark Text, please let us know!]

clarity


> [Open] an Issue

clarity: `Open` feels better than `Shoot`.
